### PR TITLE
Fix issue with torch.Tensor property ndim in older versions of Pytorch

### DIFF
--- a/warm/functional.py
+++ b/warm/functional.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import numpy as np
 from warm import engine
-
+from warm import util
 
 permute = engine.permute
 

--- a/warm/util.py
+++ b/warm/util.py
@@ -7,6 +7,8 @@ import torch.nn as nn
 import numpy as np
 import re
 
+""" Create a property for class torch.Tensor called ndim. """
+torch.Tensor.ndim = property(lambda x: x.dim())
 
 def camel_to_snake(name):
     """ Convert a camelCaseString to its snake_case_equivalent. """


### PR DESCRIPTION
**WHAT**

The property ndim of class torch.Tensor was introduced in the stable release of Pytorch version 1.2. Upon running the convnet for MNIST example with Pytorch<1.2, the following AttributeError was encountered-
`AttributeError: 'Tensor' object has no attribute 'ndim'`

**FIX**

Create a property called ndim for backward compatibility with Pytorch versions <1.2
