### PR TITLE
Documentation change - Activation keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ self.conv2 = nn.Conv2d(20, 50, 5, 1)
 -   One unified `W.conv` for all 1D, 2D, and 3D cases. Fewer things to keep track of!
 
 -   `activation='relu'`. All `warm.functional` APIs accept an optional `activation` keyword,
-    which is basically equivalent to `F.relu(W.conv(...))`.
+    which is basically equivalent to `F.relu(W.conv(...))`. The keyword `activation` can also 
+    take in a callable, for eg. `activation=torch.nn.ReLU(inplace=True)` or `activation=swish`
 
 For deeper neural networks, see additional [examples](https://blue-season.github.io/pywarm/docs/example/).
 


### PR DESCRIPTION
**WHAT**

A document change has been made w.r.t the activation keyword. 

It is difficult to pass a str as the value for activation keyword, always. This edit will make it easier to refer to, in case a user desires to use the LeakyReLU activation.
`activation=torch.nn.LeakyReLU(negative_slope=0.1, inplace=True)`

The addition of this text will also help in the user not confusing between the callable and 2-tuple input types for the spec keyword in the warm.engine.activate function. 